### PR TITLE
bugfix/subtitle not show html inside

### DIFF
--- a/components/Subtitle.js
+++ b/components/Subtitle.js
@@ -1,7 +1,8 @@
 export default function Subtitle({ children }) {
   return (
     <h4 className="subtitle">
-      {children}
+      {/* eslint-disable-next-line react/no-danger  */}
+      <div dangerouslySetInnerHTML={{ __html: children }} />
     </h4>
   );
 }


### PR DESCRIPTION
This change solve the problem to use highlighted text on the subtitle

From 
![image](https://user-images.githubusercontent.com/11279180/129059800-c75dc418-a60d-40a3-b8bf-74eda5aa9035.png)

To
![image](https://user-images.githubusercontent.com/11279180/129059944-bef3dc23-23d2-444f-9e7a-510215397b74.png)
