### PR TITLE
bugfix/stamp

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -28,7 +28,7 @@ export default function Footer({ data }) {
             </div>
           </div>
           <div className="footer__stamp">
-            <Stamp position="right" />
+            <Stamp position="right" size="small" />
           </div>
           <p className="footer__copy">
             {copyrightStatement}

--- a/components/Stamp.js
+++ b/components/Stamp.js
@@ -1,5 +1,9 @@
-export default function Stamp({ position }) {
-  const stampClass = position ? `stamp stamp--${position}` : 'stamp';
+export default function Stamp({ position, size }) {
+  const stampPosition = position ? `stamp--${position}` : '';
+  const stampSize = size ? `stamp--${size}` : '';
+
+  const stampClass = `stamp ${stampPosition} ${stampSize}`;
+
   return (
     <img src="/sello.svg" alt="Sello de Bardo" className={`${stampClass}`} />
   );

--- a/styles/components/_stamp.scss
+++ b/styles/components/_stamp.scss
@@ -1,17 +1,26 @@
 .stamp {
-  width: 78px;
+  width: 115px;
+  height: 115px;
+
+  &--small {
+    width: 78px;
+    height: 78px;
+  }
 }
 
 @media screen and (min-width: ($tablet-viewport+1)) {
   .stamp {
-    width: 115px;
-
     &--right {
       transform: translateX(50%);
     }
 
     &--left {
       transform: translateX(-50%);
+    }
+
+    &--small {
+      width: 115px;
+      height: 115px;
     }
   }
 }


### PR DESCRIPTION
The stamp used to **resize** to a smaller one based on the page's **viewport**. The problem is that the only instance where this should happen is in the Footer and nowhere else.

Now it only readjusts in the footer unless you pass in the size parameter to the instance you're creating.