### PR TITLE
bugfix/stylelint-scss-plugin

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,10 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": "stylelint-config-standard",
+    "plugins": [
+    "stylelint-scss"
+  ],
+  "rules": {
+    "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": true
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5621,6 +5621,19 @@
         "stylelint-config-recommended": "^5.0.0"
       }
     },
+    "stylelint-scss": {
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.20.1.tgz",
+      "integrity": "sha512-OTd55O1TTAC5nGKkVmUDLpz53LlK39R3MImv1CfuvsK7/qugktqiZAeQLuuC4UBhzxCnsc7fp9u/gfRZwFAIkA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
     "stylis": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "husky": "^7.0.1",
     "lint-staged": "^11.1.1",
     "stylelint": "^13.13.1",
-    "stylelint-config-standard": "^22.0.0"
+    "stylelint-config-standard": "^22.0.0",
+    "stylelint-scss": "^3.20.1"
   }
 }


### PR DESCRIPTION
## Description
Stylelint was detecting SCSS at-rules as unknown, due to it being configured for standard CSS. Now at-rules such as @mixin can be **safely used**.

Please remember to do **npm-install** after including these changes.

## To reproduce
If you attempt to include a @mixin in the current project, vscode-stylelint will inmediately signal an error, therefore, it's **not possible to commit changes**.

## Screenshots

Before including the plugin:

![imagen](https://user-images.githubusercontent.com/24487667/129428125-197e9f4b-0f5e-45dd-8ef1-d0b31d4ead58.png)