### PR TITLE
Add Statement component for mision and vision information

### DIFF
--- a/components/Statements/Statement.js
+++ b/components/Statements/Statement.js
@@ -5,9 +5,9 @@ export default function Statement(props) {
 
   return (
     <div className="statement">
-      <div className="statement__title">
-        <div className="statement__title--eyebrow">{eyebrow}</div>
-        <Title data={title} className="statement__title--color" />
+      <div className="statement__title__container">
+        <div className="statement__title__eyebrow">{eyebrow}</div>
+        <Title data={title} className="statement__title" />
       </div>
       <div className="statement__description">{description}</div>
     </div>

--- a/components/Statements/Statement.js
+++ b/components/Statements/Statement.js
@@ -1,0 +1,15 @@
+import Title from '../Title';
+
+export default function Statement(props) {
+  const { eyebrow, title, description } = props;
+
+  return (
+    <div className="statement">
+      <div className="statement__title">
+        <div className="statement__title--eyebrow">{eyebrow}</div>
+        <Title data={title} className="statement__title--color" />
+      </div>
+      <div className="statement__description">{description}</div>
+    </div>
+  );
+}

--- a/components/Statements/Statements.js
+++ b/components/Statements/Statements.js
@@ -1,0 +1,37 @@
+import { getContentfulStatements } from '../../utils/contentful';
+import Statement from './Statement';
+
+export default function Statements(props) {
+  const statements = getContentfulStatements(props);
+  const [mision, vision] = statements;
+
+  const {
+    eyebrowText: misionEyebrow,
+    title: misionTitle,
+    description: misionDescription,
+  } = mision.fields;
+
+  const {
+    eyebrowText: visionEyebrow,
+    title: visionTitle,
+    description: visionDescription,
+  } = vision.fields;
+
+  return (
+    <section className="statements">
+      <div className="line" />
+      <div className="statements__wrapper">
+        <Statement
+          eyebrow={misionEyebrow}
+          title={misionTitle}
+          description={misionDescription}
+        />
+        <Statement
+          eyebrow={visionEyebrow}
+          title={visionTitle}
+          description={visionDescription}
+        />
+      </div>
+    </section>
+  );
+}

--- a/pages/quienes-somos.js
+++ b/pages/quienes-somos.js
@@ -1,5 +1,6 @@
 import getPageData from '../utils/api';
 import Objectives from '../components/Objectives/Objectives';
+import Statements from '../components/Statements/Statements';
 
 export const getServerSideProps = async () => {
   const pageData = await getPageData('quienes-somos');
@@ -15,6 +16,7 @@ export const getServerSideProps = async () => {
 export default function QuienesSomos({ data }) {
   return (
     <div>
+      <Statements data={data} />
       <Objectives data={data} />
     </div>
   );

--- a/styles/base/_base.scss
+++ b/styles/base/_base.scss
@@ -32,3 +32,9 @@ a {
 .page-content {
   margin-top: 64px;
 }
+
+.line {
+  width: 100%;
+  height: 11px;
+  background-color: var(--tuscany);
+}

--- a/styles/components/_profiles.scss
+++ b/styles/components/_profiles.scss
@@ -25,12 +25,6 @@
   }
 }
 
-.line {
-  width: 100%;
-  height: 11px;
-  background-color: var(--tuscany);
-}
-
 @media screen and (max-width: ($tablet-viewport+1)) {
   .profiles {
     background-color: var(--white);

--- a/styles/components/_statement.scss
+++ b/styles/components/_statement.scss
@@ -11,13 +11,13 @@
   grid-template-columns: repeat(12, 1fr);
 
   &__title {
-    grid-column: 3/5;
+    color: var(--pueblo);
 
-    &--color {
-      color: var(--pueblo);
+    &__container {
+      grid-column: 3/5;
     }
 
-    &--eyebrow {
+    &__eyebrow {
       font-size: 0.625rem;
       line-height: 0.938rem;
       letter-spacing: 0.15em;
@@ -60,11 +60,11 @@
     }
 
     &__title {
-      padding-bottom: 16px;
+      font-size: 1.5rem;
+      line-height: 2.25rem;
 
-      &--color {
-        font-size: 1.5rem;
-        line-height: 2.25rem;
+      &__container {
+        padding-bottom: 16px;
       }
     }
   }

--- a/styles/components/statements/_statement.scss
+++ b/styles/components/statements/_statement.scss
@@ -1,0 +1,71 @@
+.statements__wrapper {
+  width: auto;
+  min-height: 503px;
+  display: grid;
+  grid-column: auto;
+  padding-top: 95px;
+}
+
+.statement {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+
+  &__title {
+    grid-column: 3/5;
+
+    &--color {
+      color: var(--pueblo);
+    }
+
+    &--eyebrow {
+      font-size: 0.625rem;
+      line-height: 0.938rem;
+      letter-spacing: 0.15em;
+      color: var(--orange);
+    }
+  }
+
+  &__description {
+    grid-column: 5/11;
+    max-width: 684px;
+    line-height: 1.5rem;
+    font-size: 1rem;
+    letter-spacing: 0.001em;
+    color: var(--cod-gray);
+    margin-left: 48px;
+    max-height: 119px;
+  }
+}
+
+@media screen and (max-width: ($tablet-viewport)) {
+  .statements__wrapper {
+    padding-top: 32px;
+    margin-right: 17px;
+    display: flex;
+    flex-direction: column;
+    max-height: 702px;
+  }
+
+  .statement {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 24px;
+    margin-left: 26px;
+
+    &__description {
+      width: auto;
+      letter-spacing: 0.005em;
+      margin-left: 0;
+      max-height: fit-content;
+    }
+
+    &__title {
+      padding-bottom: 16px;
+
+      &--color {
+        font-size: 1.5rem;
+        line-height: 2.25rem;
+      }
+    }
+  }
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -32,7 +32,7 @@
 @import "swiper/components/pagination/pagination.scss";
 @import "./components/objectives";
 @import "./components/objectivesCard";
-@import "./components/statements/statement.scss";
+@import "./components/statement.scss";
 
 @media screen and (max-width: ($tablet-viewport+1)) {
   .line {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -32,3 +32,10 @@
 @import "swiper/components/pagination/pagination.scss";
 @import "./components/objectives";
 @import "./components/objectivesCard";
+@import "./components/statements/statement.scss";
+
+@media screen and (max-width: ($tablet-viewport+1)) {
+  .line {
+    height: 2px;
+  }
+}

--- a/utils/contentful.js
+++ b/utils/contentful.js
@@ -41,3 +41,8 @@ export function getContentfulObjectives(data) {
   dataContentful.sectionTitle = sectionObjectives.sectionTitle;
   return dataContentful;
 }
+
+export function getContentfulStatements(data) {
+  const statements = data.data.items[0].fields.components[2].fields.sectionComponents;
+  return statements;
+}


### PR DESCRIPTION
# FooCamp - Bardo

## Trello ticket
https://trello.com/c/ANgXAWuZ/51-quienes-somos-mision-vision-funcionalidad-dise%C3%B1o-sp2

## Description
Creation of Statement component to display Mision & Vision information. The component has the following properties:

**eyebrown**: statement identifier
**title**: Title of statement
**description**: description of statement

## To reproduce
Provide clear instructions to check the new feature (or to reproduce the issue).

1. Run the project
2. Open the specific page http://localhost:3000/quienes-somos
3. Check the component

## Screenshots

Desktop
![Screen Shot 2021-08-21 at 1 50 06 PM](https://user-images.githubusercontent.com/68615447/130332058-112935e3-9e64-4c49-9ce4-f6cfb9823873.png)


Mobile
![image](https://user-images.githubusercontent.com/68615447/130332070-90d694f3-f316-4259-9180-b8006df89f75.png)
