### PR TITLE
Add container component and fix components order

### DIFF
--- a/components/Statements/Statements.js
+++ b/components/Statements/Statements.js
@@ -1,5 +1,6 @@
 import { getContentfulStatements } from '../../utils/contentful';
 import Statement from './Statement';
+import Container from '../Container';
 
 export default function Statements(props) {
   const statements = getContentfulStatements(props);
@@ -20,7 +21,7 @@ export default function Statements(props) {
   return (
     <section className="statements">
       <div className="line" />
-      <div className="statements__wrapper">
+      <Container className="statements__wrapper">
         <Statement
           eyebrow={misionEyebrow}
           title={misionTitle}
@@ -31,7 +32,7 @@ export default function Statements(props) {
           title={visionTitle}
           description={visionDescription}
         />
-      </div>
+      </Container>
     </section>
   );
 }

--- a/pages/quienes-somos.js
+++ b/pages/quienes-somos.js
@@ -17,9 +17,9 @@ export const getServerSideProps = async () => {
 export default function QuienesSomos({ data }) {
   return (
     <div>
+      <ChildHero data={data} />
       <Statements data={data} />
       <Objectives data={data} />
-      <ChildHero data={data} />
     </div>
   );
 }

--- a/styles/components/_statement.scss
+++ b/styles/components/_statement.scss
@@ -40,17 +40,16 @@
 @media screen and (max-width: ($tablet-viewport)) {
   .statements__wrapper {
     padding-top: 32px;
-    margin-right: 17px;
     display: flex;
     flex-direction: column;
     max-height: 702px;
+    margin-bottom: 8px;
   }
 
   .statement {
     display: flex;
     flex-direction: column;
     padding-bottom: 24px;
-    margin-left: 26px;
 
     &__description {
       width: auto;


### PR DESCRIPTION
# FooCamp - Bardo

## Trello ticket
https://trello.com/c/ANgXAWuZ/51-quienes-somos-mision-vision-funcionalidad-dise%C3%B1o-sp2

## Description
Fix layout issue adding the Container component and add correct order to components on Quienes Somos page

## To reproduce

1. Run the project
2. Open the specific page https://localhost:3000/quienes-somos
3. Check the component

## Screenshots

Desktop
![image](https://user-images.githubusercontent.com/68615447/130700409-746a7f68-56af-4a4d-b117-e37a22fb9258.png)


Mobile
![image](https://user-images.githubusercontent.com/68615447/130700507-81724d34-6e21-46ab-ba5b-a0a23ff62e9e.png)


