### PR TITLE
Add button information (text & link) from contentful and fix some styles

### DIFF
--- a/components/ArtworkArticle/ArtworkArticle.js
+++ b/components/ArtworkArticle/ArtworkArticle.js
@@ -2,7 +2,7 @@ import ArtworkImageGallery from './ArtworkImageGallery';
 import ArtworkDetailsBlock from './ArtworkDetailsBlock';
 import Container from '../Container';
 
-export default function ArtworkArticle({ data, pageData }) {
+export default function ArtworkArticle({ data, pageData, buttonData }) {
   const { heroDescription, heroTag, heroTitle } = pageData;
 
   return (
@@ -16,7 +16,7 @@ export default function ArtworkArticle({ data, pageData }) {
 
         <div className="artwork-article__body-container">
           <ArtworkImageGallery data={data} />
-          <ArtworkDetailsBlock data={data} />
+          <ArtworkDetailsBlock data={data} buttonData={buttonData} />
         </div>
       </Container>
     </article>

--- a/components/ArtworkArticle/ArtworkDetailsBlock.js
+++ b/components/ArtworkArticle/ArtworkDetailsBlock.js
@@ -1,13 +1,14 @@
 import ArtworkDetails from './ArtworkDetails';
 import Button from '../Button';
-import { openInCurrentTab } from '../../utils/window';
+import { openInCurrentTab, openInNewTab } from '../../utils/window';
 
-export default function ArtworkDetailsBlock({ data }) {
+export default function ArtworkDetailsBlock({ data, buttonData }) {
   const {
     author, dimensions, technique, price, edition, cardDescription, availability,
   } = data.fields;
   const details = { dimensions, technique, price };
-  const buttonText = availability ? 'MÁS INFORMACIÓN DE ESTA OBRA' : 'OBRA NO DISPONIBLE';
+  const { buttonLink, buttonText } = buttonData;
+  const text = availability ? buttonText : 'OBRA NO DISPONIBLE';
 
   return (
     <section className="artwork-details__container">
@@ -22,8 +23,9 @@ export default function ArtworkDetailsBlock({ data }) {
       <div className="artwork-details__cta-container">
         <Button
           buttonstyle="button button--primary button--artwork"
-          text={buttonText}
+          text={text}
           disabled={!availability}
+          onclick={() => openInNewTab(buttonLink)}
         />
         <Button
           buttonstyle="button button--secondary button--artwork button--artwork-return"

--- a/pages/obras/[artwork].js
+++ b/pages/obras/[artwork].js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { getContentfulArtworkDetailsPageData, getContentfulSingleArtworkData } from '../../utils/contentful';
+import { getContentfulArtworkDetailsPageData, getContentfulSingleArtworkData, getContentfulArtworkDetailsButtonData } from '../../utils/contentful';
 import getPageData from '../../utils/api';
 import ArtworkArticle from '../../components/ArtworkArticle/ArtworkArticle';
 
@@ -20,10 +20,11 @@ export default function Artwork({ data, pageData }) {
   const { artwork: selectedArtworkName } = router.query;
   const artworkData = getContentfulSingleArtworkData(data, selectedArtworkName);
   const detailsPageData = getContentfulArtworkDetailsPageData(pageData);
+  const buttonData = getContentfulArtworkDetailsButtonData(pageData);
 
   return (
     <div className="home">
-      <ArtworkArticle data={artworkData} pageData={detailsPageData} />
+      <ArtworkArticle data={artworkData} pageData={detailsPageData} buttonData={buttonData} />
     </div>
   );
 }

--- a/styles/components/_artworkArticleDetails.scss
+++ b/styles/components/_artworkArticleDetails.scss
@@ -8,6 +8,8 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     margin: 36px 0 36px 0;
+    font-size: 0.875rem;
+    letter-spacing: 0.0025em;
   }
 
   &__title {
@@ -20,6 +22,8 @@
 
   &__description {
     margin: 29px 0 64px 0;
+    font-size: 0.875rem;
+    letter-spacing: 0.0025em;
   }
 
   &__information-container {

--- a/styles/components/_artworkArticleDetails.scss
+++ b/styles/components/_artworkArticleDetails.scss
@@ -53,7 +53,7 @@
     }
 
     &__details-container {
-      margin: 36px 0 55px 0;
+      margin: 36px 0 36px 0;
     }
 
     &__cta-container {

--- a/utils/contentful.js
+++ b/utils/contentful.js
@@ -98,3 +98,7 @@ export function getContentfulProfileDetail(data) {
 export function getContentfulProfileHeroData(data) {
   return data.items[0].fields.components[1].fields;
 }
+
+export function getContentfulArtworkDetailsButtonData(data) {
+  return data.items[0].fields.components[3].fields;
+}


### PR DESCRIPTION
# FooCamp - Bardo

## Trello ticket
https://trello.com/c/CYY82LIo/73-obras-testing

## Description
Add button functionality to open whatsapp new tab and retrieve text button from contentful
Fix styles to match wireframe

## To reproduce
Provide clear instructions to check the new feature (or to reproduce the issue).

1. Run the project
2. Open the specific page http://localhost:3000
3. Check the Obras section
4. Click in one Obra item
5. Check the components
6. Click on "Mas informacion de obra"

## Screenshots

![Screen Shot 2021-09-21 at 3 53 22 PM](https://user-images.githubusercontent.com/68615447/134246132-8b0d5e68-9f7b-4cf8-897c-4c23422babeb.png)

