### PR TITLE
bugfix/missing-artwork-name

### DIFF
--- a/components/ArtworkArticle/ArtworkDetailsBlock.js
+++ b/components/ArtworkArticle/ArtworkDetailsBlock.js
@@ -4,7 +4,7 @@ import { openInCurrentTab, openInNewTab } from '../../utils/window';
 
 export default function ArtworkDetailsBlock({ data, buttonData }) {
   const {
-    author, dimensions, technique, price, edition, cardDescription, availability,
+    author, dimensions, cardTitle, technique, price, edition, cardDescription, availability,
   } = data.fields;
   const details = { dimensions, technique, price };
   const { buttonLink, buttonText } = buttonData;
@@ -14,7 +14,13 @@ export default function ArtworkDetailsBlock({ data, buttonData }) {
     <section className="artwork-details__container">
       <div className="artwork-details__information-container">
         <h4 className="artwork-details__title">{ author }</h4>
-        <h6 className="artwork-details__title-year">{edition}</h6>
+        <h6 className="artwork-details__title-year">
+          {cardTitle}
+          {' '}
+          (
+          {edition}
+          )
+        </h6>
         <div className="artwork-details__separator" />
         <ArtworkDetails data={details} />
         <div className="artwork-details__separator" />


### PR DESCRIPTION
Missing artwork name on artwork article. Now placed accordingly with the art piece edition.

![image](https://user-images.githubusercontent.com/24487667/137039973-951da063-053b-4130-9a6c-12cf931ef91f.png)