### PR TITLE
Link target on menu-profile and height of thumb in artwork

### DIFF
--- a/components/NavLink.js
+++ b/components/NavLink.js
@@ -1,11 +1,12 @@
 import Link from 'next/link';
 
 export default function NavLink({ linkLabel, linkUrl }) {
+  const target = (linkUrl.length > 0 && linkUrl.substr(0, 1) !== '/') && '_blank';
   return (
     <li className="navigation__item">
       <Link href={linkUrl}>
         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-        <a>{linkLabel}</a>
+        <a target={target}>{linkLabel}</a>
       </Link>
     </li>
   );

--- a/components/ProfileCard.js
+++ b/components/ProfileCard.js
@@ -1,13 +1,12 @@
+import { useRouter } from 'next/router';
 import Button from './Button';
 import ProfileTitle from './ProfileTitle';
+import { openInCurrentTab } from '../utils/window';
 
 export default function Card({
   title, description, link, image, buttontext,
 }) {
-  const openInNewTab = (url) => {
-    const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
-    if (newWindow) newWindow.opener = null;
-  };
+  const router = useRouter();
 
   return (
     <article className="profile">
@@ -19,7 +18,7 @@ export default function Card({
       <Button
         containerStyle="profile__button"
         buttonstyle="button button--primary"
-        onclick={() => openInNewTab(link)}
+        onclick={() => openInCurrentTab(link, router)}
         text={buttontext}
       />
     </article>

--- a/styles/components/_artworkImageGallery.scss
+++ b/styles/components/_artworkImageGallery.scss
@@ -17,6 +17,7 @@
 
 .artworkImageGallery__thumbs--item {
   width: auto;
+  max-height: 100px;
 }
 
 .artworkImageGallery__container {
@@ -25,7 +26,7 @@
 
 .artworkImageGallery__navigation {
   padding: 30px 130px !important;
-  height: 30%;
+  height: 160px;
 }
 
 .artworkImageGallery__navigation .swiper-slide {


### PR DESCRIPTION
## Description
Link target on menu to blank page when its from other page (ejm. whatsapp)
Change the profile from home to profile page on current tab
Height of thumb in artwork

## To reproduce
1. Run the project
--
2. Open any page
3. Check the nav link, test with Contacto and Que hacemos
--
2. Open the specific page (http://localhost:3000/home)
3. Check the profile section
--
2. Open the specific page (http://localhost:3000/obras/dualidad-muerte)
3. Check the thumb images

## Screenshots
1.  From
![image](https://user-images.githubusercontent.com/11279180/138512722-21b26e9b-7fd3-421a-85af-5af810310ea5.png)

1.  To
![image](https://user-images.githubusercontent.com/11279180/138512643-35db9646-6b6c-4d38-9e73-793ac4bfb05b.png)
